### PR TITLE
Feature/image-fat-trimming: Reduce size of final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,22 @@ WORKDIR /app
 RUN apk update && apk add --no-cache nginx supervisor
 
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+
+# Install Pydantic and pydantic-core from Alpine packages ONLY for ARM
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ] || [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    apk add --no-cache py3-pydantic py3-pydantic-core; \
+fi
+
+# Install Python dependencies (excluding pydantic and pydantic-core for ARM)
+COPY api/requirements.txt .
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ] || [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    pip install --no-cache-dir --no-binary pydantic-core,pydantic -r requirements.txt; \
+else \
+    pip install --no-cache-dir -r requirements.txt; \
+fi
+
+# Install build dependencies for other potential native extensions on ARM (as a fallback)
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ] || [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     apk update && apk add --no-cache --virtual .build-deps \
         gcc \
         musl-dev \
@@ -27,11 +42,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
         rust cargo; \
 fi
 
-# Install Python dependencies
-COPY api/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+# Clean up build dependencies for ARM
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ] || [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     apk del .build-deps; \
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,23 @@ WORKDIR /app
 # Install Nginx and Supervisor first
 RUN apk update && apk add --no-cache nginx supervisor
 
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+    apk update && apk add --no-cache --virtual .build-deps \
+        gcc \
+        musl-dev \
+        linux-headers \
+        python3-dev \
+        rust cargo; \
+fi
+
 # Install Python dependencies
 COPY api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+    apk del .build-deps; \
+fi
 
 # Copy backend files
 COPY api/ ./api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-# Stage 1: Build the frontend
+# ==============================================================================
+# Stage 1: Frontend build
+# ==============================================================================
 FROM node:22 as frontend-builder
 WORKDIR /app
 COPY client/package.json client/package-lock.json ./
-RUN npm install
+RUN npm ci
 COPY client/ ./
 RUN npm run build
 
-# Stage 2: Build the backend
-FROM python:3.13-slim as backend
+# ==============================================================================
+# Stage 2: Final image
+# ==============================================================================
+FROM python:3.13-alpine as backend
 WORKDIR /app
 
 # Install Nginx and Supervisor first
-RUN apt-get update && apt-get install -y nginx supervisor && apt-get clean
+RUN apk update && apk add --no-cache nginx supervisor
 
 # Install Python dependencies
 COPY api/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend files
 COPY api/ ./api

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NotifyAgent
 
-![Screenshot](https://i.imgur.com/hm8VLCv.png)
+![Screenshot](https://i.imgur.com/IfyWMDQ.png)
 
 ## Docker-less Setup:
 

--- a/api/supervisord.conf
+++ b/api/supervisord.conf
@@ -17,5 +17,5 @@ stderr_logfile_maxbytes=0
 command=nginx -g "daemon off;"
 autostart=true
 autorestart=true
-stdout_logfile=/var/log/supervisor/nginx_stdout.log
-stderr_logfile=/var/log/supervisor/nginx_stderr.log
+stdout_logfile=/var/log/nginx_stdout.log
+stderr_logfile=/var/log/nginx_stderr.log


### PR DESCRIPTION
Changes:
- Switch from python:3.13-slim (Debian) to python:3.13-alpine: cuts final image size from ~245MB to ~143MB
- Small adjustments to Dockerfile - cleanup stage separation
- Overdue: Update screenshot in README to reflect UI changes

CURRENT ISSUE: CI builds extremely slow for ARM - given alpine base image (musl), pydantic wheel must be built, causing a ~20 min build.  Will keep this open for the time-being until a good solution is found.